### PR TITLE
feat: emphasize phone contact and remove email

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,10 @@
               href="#contact"
               class="text-gray-700 hover:text-red-600 font-medium transition-colors"
               >Contact</a>
+            <a
+              href="tel:+18143152544"
+              class="text-gray-700 hover:text-red-600 font-medium transition-colors"
+              >814-315-2544</a>
           </nav>
           <button
             id="mobile-menu-button"
@@ -145,6 +149,10 @@
             href="#contact"
             class="text-gray-700 hover:text-red-600 font-medium transition-colors"
             >Contact</a>
+          <a
+            href="tel:+18143152544"
+            class="text-gray-700 hover:text-red-600 font-medium transition-colors"
+            >814-315-2544</a>
         </div>
       </div>
     </header>
@@ -624,30 +632,15 @@
                         />
                       </svg>
                     </div>
-                    <div>
-                      <h4 class="font-semibold text-lg mb-1">Phone</h4>
-                      <p class="text-gray-300">+1 (814) 315-2544</p>
-                    </div>
+                  <div>
+                    <h4 class="font-semibold text-lg mb-1">Phone</h4>
+                    <p class="text-gray-300">
+                      <a href="tel:+18143152544" class="hover:text-white">
+                        +1 (814) 315-2544
+                      </a>
+                    </p>
                   </div>
-
-                  <div class="flex items-start space-x-4">
-                    <div class="bg-green-600 p-3 rounded-full flex-shrink-0">
-                      <svg
-                        class="w-6 h-6 text-white"
-                        fill="currentColor"
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
-                      >
-                        <path
-                          d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"
-                        />
-                      </svg>
-                    </div>
-                    <div>
-                      <h4 class="font-semibold text-lg mb-1">Email</h4>
-                      <p class="text-gray-300">WileyTruckingFleet@icloud.com</p>
-                    </div>
-                  </div>
+                </div>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- feature: add phone number as clickable `tel:` link in desktop and mobile nav
- feature: make contact section phone clickable and remove iCloud email

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad325e2dec83318f19c76d6ba2d757