### PR TITLE
Revamp services cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <script src="https://cdn.tailwindcss.com"></script>
     <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Lato:wght@300;400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Lato:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
@@ -58,7 +58,7 @@
   <body class="font-lato bg-gray-50">
     <!-- Sticky CTA Button -->
     <button
-      class="sticky-cta bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded-full font-montserrat font-semibold text-sm uppercase tracking-wide shadow-lg transition-all duration-300"
+      class="sticky-cta bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded-full font-montserrat font-semibold text-sm uppercase tracking-wide transition-all duration-300"
       onclick="document.getElementById('contact').scrollIntoView()"
     >
       Get a Quote
@@ -300,7 +300,7 @@
     </section>
 
     <!-- Services Section -->
-    <section id="services" class="py-20 bg-gray-50">
+    <section id="services" class="py-20 bg-gray-100">
       <div class="container mx-auto px-4">
         <div class="text-center mb-16">
           <h2 class="font-montserrat font-bold text-4xl text-gray-800 mb-4">
@@ -312,106 +312,121 @@
           </p>
         </div>
 
-        <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
-          <div
-            class="service-card bg-white p-8 rounded-xl shadow-lg text-center transition-all duration-300 cursor-pointer"
+        <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-5 md:gap-8">
+          <a
+            href="#contact"
+            aria-label="Learn about Line Haul — 53' Dry Van"
+            class="service-card block bg-white p-6 rounded-2xl text-center transition-all duration-300"
           >
             <div
-              class="bg-red-50 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
+              class="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-6 bg-red-600/15"
             >
               <svg
-                class="w-8 h-8 text-red-600"
+                class="w-6 h-6 text-red-600"
                 fill="currentColor"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
-                <path
-                  d="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4z"
-                />
+                <path d="M3.375 4.5C2.339 4.5 1.5 5.34 1.5 6.375V13.5h12V6.375c0-1.036-.84-1.875-1.875-1.875h-8.25ZM13.5 15h-12v2.625c0 1.035.84 1.875 1.875 1.875h.375a3 3 0 1 1 6 0h3a.75.75 0 0 0 .75-.75V15Z" />
+                <path d="M8.25 19.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0ZM15.75 6.75a.75.75 0 0 0-.75.75v11.25c0 .087.015.17.042.248a3 3 0 0 1 5.958.464c.853-.175 1.522-.935 1.464-1.883a18.659 18.659 0 0 0-3.732-10.104 1.837 1.837 0 0 0-1.47-.725H15.75Z" />
+                <path d="M19.5 19.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0Z" />
               </svg>
             </div>
             <h3
-              class="font-montserrat font-semibold text-lg text-gray-800 mb-2"
+              class="font-montserrat font-bold text-[22px] text-gray-900 tracking-tight mb-2"
             >
               Line Haul
             </h3>
-            <p class="text-red-600 font-medium">53′ Dry Van</p>
-          </div>
+            <p class="text-base font-medium text-gray-700">53′ Dry Van</p>
+          </a>
 
-          <div
-            class="service-card bg-white p-8 rounded-xl shadow-lg text-center transition-all duration-300 cursor-pointer"
+          <a
+            href="#contact"
+            aria-label="Learn about Tanker & Doubles/Triples"
+            class="service-card block bg-white p-6 rounded-2xl text-center transition-all duration-300"
           >
             <div
-              class="bg-blue-50 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
+              class="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-6 bg-blue-600/15"
             >
               <svg
-                class="w-8 h-8 text-blue-600"
+                class="w-6 h-6 text-blue-600"
                 fill="currentColor"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z"
-                />
+                <path fill-rule="evenodd" d="M10.5 3.798v5.02a3 3 0 0 1-.879 2.121l-2.377 2.377a9.845 9.845 0 0 1 5.091 1.013 8.315 8.315 0 0 0 5.713.636l.285-.071-3.954-3.955a3 3 0 0 1-.879-2.121v-5.02a23.614 23.614 0 0 0-3 0Zm4.5.138a.75.75 0 0 0 .093-1.495A24.837 24.837 0 0 0 12 2.25a25.048 25.048 0 0 0-3.093.191A.75.75 0 0 0 9 3.936v4.882a1.5 1.5 0 0 1-.44 1.06l-6.293 6.294c-1.62 1.621-.903 4.475 1.471 4.88 2.686.46 5.447.698 8.262.698 2.816 0 5.576-.239 8.262-.697 2.373-.406 3.092-3.26 1.47-4.881L15.44 9.879A1.5 1.5 0 0 1 15 8.818V3.936Z" clip-rule="evenodd" />
               </svg>
             </div>
             <h3
-              class="font-montserrat font-semibold text-lg text-gray-800 mb-2"
+              class="font-montserrat font-bold text-[22px] text-gray-900 tracking-tight mb-2"
             >
-              Tanker &
+              Tanker & Doubles/Triples
             </h3>
-            <p class="text-blue-600 font-medium">Doubles/Triples</p>
-          </div>
+            <p class="text-base font-medium text-gray-700">HazMat/TWIC as needed</p>
+          </a>
 
-          <div
-            class="service-card bg-white p-8 rounded-xl shadow-lg text-center transition-all duration-300 cursor-pointer"
+          <a
+            href="#contact"
+            aria-label="Learn about TWIC-Certified Drivers"
+            class="service-card block bg-white p-6 rounded-2xl text-center transition-all duration-300"
           >
             <div
-              class="bg-green-50 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
+              class="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-6 bg-green-600/15"
             >
               <svg
-                class="w-8 h-8 text-green-600"
+                class="w-6 h-6 text-green-600"
                 fill="currentColor"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
-                <path
-                  d="M12 1L3 5V11C3 16.55 6.84 21.74 12 23C17.16 21.74 21 16.55 21 11V5L12 1M10 17L6 13L7.41 11.59L10 14.17L16.59 7.58L18 9L10 17Z"
-                />
+                <path fill-rule="evenodd" d="M4.5 3.75a3 3 0 0 0-3 3v10.5a3 3 0 0 0 3 3h15a3 3 0 0 0 3-3V6.75a3 3 0 0 0-3-3h-15Zm4.125 3a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Zm-3.873 8.703a4.126 4.126 0 0 1 7.746 0 .75.75 0 0 1-.351.92 7.47 7.47 0 0 1-3.522.877 7.47 7.47 0 0 1-3.522-.877.75.75 0 0 1-.351-.92ZM15 8.25a.75.75 0 0 0 0 1.5h3.75a.75.75 0 0 0 0-1.5H15ZM14.25 12a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H15a.75.75 0 0 1-.75-.75Zm.75 2.25a.75.75 0 0 0 0 1.5h3.75a.75.75 0 0 0 0-1.5H15Z" clip-rule="evenodd" />
               </svg>
             </div>
             <h3
-              class="font-montserrat font-semibold text-lg text-gray-800 mb-2"
+              class="font-montserrat font-bold text-[22px] text-gray-900 tracking-tight mb-2"
             >
-              TWIC-Certified
+              TWIC-Certified Drivers
             </h3>
-            <p class="text-green-600 font-medium">Drivers</p>
-          </div>
+            <p class="text-base font-medium text-gray-700">Access to secure sites</p>
+          </a>
 
-          <div
-            class="service-card bg-white p-8 rounded-xl shadow-lg text-center transition-all duration-300 cursor-pointer"
+          <a
+            href="#contact"
+            aria-label="Learn about Real-Time Tracking"
+            class="service-card block bg-white p-6 rounded-2xl text-center transition-all duration-300"
           >
             <div
-              class="bg-purple-50 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
+              class="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-6 bg-purple-600/15"
             >
               <svg
-                class="w-8 h-8 text-purple-600"
+                class="w-6 h-6 text-purple-600"
                 fill="currentColor"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
-                <path
-                  d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
-                />
+                <path fill-rule="evenodd" d="m11.54 22.351.07.04.028.016a.76.76 0 0 0 .723 0l.028-.015.071-.041a16.975 16.975 0 0 0 1.144-.742 19.58 19.58 0 0 0 2.683-2.282c1.944-1.99 3.963-4.98 3.963-8.827a8.25 8.25 0 0 0-16.5 0c0 3.846 2.02 6.837 3.963 8.827a19.58 19.58 0 0 0 2.682 2.282 16.975 16.975 0 0 0 1.145.742ZM12 13.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" clip-rule="evenodd" />
               </svg>
             </div>
             <h3
-              class="font-montserrat font-semibold text-lg text-gray-800 mb-2"
+              class="font-montserrat font-bold text-[22px] text-gray-900 tracking-tight mb-2"
             >
-              Real-Time Load
+              Real-Time Tracking
             </h3>
-            <p class="text-purple-600 font-medium">Tracking</p>
-          </div>
+            <p class="text-base font-medium text-gray-700">Live GPS updates</p>
+          </a>
+        </div>
+
+        <div class="mt-12 flex flex-col sm:flex-row justify-center gap-4">
+          <a
+            href="#contact"
+            class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded-full font-montserrat font-semibold shadow-md transition-colors"
+            >Get a Quote</a
+          >
+          <a
+            href="tel:+18143152544"
+            class="border border-red-600 text-red-600 px-6 py-3 rounded-full font-montserrat font-semibold hover:bg-red-50 transition-colors"
+            >Call Now</a
+          >
         </div>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -22,19 +22,25 @@
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
+.service-card {
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+}
+
 .service-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.14);
 }
 html {
   scroll-behavior: smooth;
 }
 .sticky-cta {
   position: fixed;
-  top: 20px;
+  bottom: calc(env(safe-area-inset-bottom) + 20px);
   right: 20px;
   z-index: 1000;
   animation: pulse 2s infinite;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 @keyframes pulse {
   0%,
@@ -48,8 +54,7 @@ html {
 
 @media (max-width: 768px) {
   .sticky-cta {
-    top: auto;
-    bottom: 20px;
+    bottom: calc(env(safe-area-inset-bottom) + 20px);
   }
 }
 


### PR DESCRIPTION
## Summary
- Strengthen typography and layout for service cards with bold Montserrat headings, medium Lato sublines and full-card links
- Add consistent icon chips, card shadows, and section-level quote/call CTAs
- Move floating Get a Quote button to bottom with safe-area spacing and subtle border/shadow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3389109883318c7838fe117360db