### PR TITLE
Use WTF.ico for icon and logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <meta property="og:url" content="https://www.wileytrucking.com/" />
     <meta
       property="og:image"
-      content="https://www.wileytrucking.com/Logo.png"
+      content="https://www.wileytrucking.com/WTF.ico"
     />
     <meta property="og:image:alt" content="Wiley Trucking Fleet logo" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -54,7 +54,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://www.wileytrucking.com/Logo.png"
+      content="https://www.wileytrucking.com/WTF.ico"
     />
     <meta name="twitter:image:alt" content="Wiley Trucking Fleet logo" />
     <link rel="canonical" href="https://www.wileytrucking.com/" />
@@ -66,10 +66,9 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/WTF.ico" />
+    <link rel="icon" type="image/x-icon" href="/WTF.ico" />
+    <link rel="shortcut icon" href="/WTF.ico" />
     <link rel="manifest" href="/site.webmanifest" />
   </head>
   <body class="font-montserrat font-bold text-gray-900 bg-gray-50">
@@ -87,7 +86,7 @@
         <div class="flex items-center justify-between">
           <div class="flex items-center space-x-3">
             <img
-              src="Logo.png"
+              src="WTF.ico"
               alt="Wiley Trucking Fleet logo"
               class="h-12 w-auto"
             />
@@ -716,7 +715,7 @@
           <div class="md:col-span-2">
             <div class="flex items-center space-x-3 mb-6">
               <img
-                src="Logo.png"
+                src="WTF.ico"
                 alt="Wiley Trucking Fleet logo"
                 class="w-10 h-10 object-contain"
               />

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -12,10 +12,9 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/WTF.ico" />
+    <link rel="icon" type="image/x-icon" href="/WTF.ico" />
+    <link rel="shortcut icon" href="/WTF.ico" />
     <link rel="manifest" href="/site.webmanifest" />
   </head>
   <body class="font-montserrat font-bold text-gray-900 bg-gray-50">
@@ -24,7 +23,7 @@
         <div class="flex items-center justify-between">
           <div class="flex items-center space-x-3">
             <img
-              src="Logo.png"
+              src="WTF.ico"
               alt="Wiley Trucking Fleet logo"
               class="h-12 w-auto"
             />
@@ -204,7 +203,7 @@
           <div class="md:col-span-2">
             <div class="flex items-center space-x-3 mb-6">
               <img
-                src="Logo.png"
+                src="WTF.ico"
                 alt="Wiley Trucking Fleet logo"
                 class="w-10 h-10 object-contain"
               />

--- a/thank-you.html
+++ b/thank-you.html
@@ -12,10 +12,9 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/WTF.ico" />
+    <link rel="icon" type="image/x-icon" href="/WTF.ico" />
+    <link rel="shortcut icon" href="/WTF.ico" />
     <link rel="manifest" href="/site.webmanifest" />
   </head>
   <body class="font-montserrat font-bold text-gray-900 bg-gray-50">
@@ -24,7 +23,7 @@
         <div class="flex items-center justify-between">
           <div class="flex items-center space-x-3">
             <img
-              src="Logo.png"
+              src="WTF.ico"
               alt="Wiley Trucking Fleet logo"
               class="h-12 w-auto"
             />
@@ -141,7 +140,7 @@
           <div class="md:col-span-2">
             <div class="flex items-center space-x-3 mb-6">
               <img
-                src="Logo.png"
+                src="WTF.ico"
                 alt="Wiley Trucking Fleet logo"
                 class="w-10 h-10 object-contain"
               />


### PR DESCRIPTION
## Summary
- replace all favicon links with WTF.ico
- use WTF.ico as the header and footer logo across pages
- update social preview images to reference WTF.ico

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4649ab788331bf501962f0729231