### PR TITLE
feat: replace mobile menu with clickable phone number

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,57 +125,14 @@
             >
             <a
               href="tel:+18143152544"
-              class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-              >814-315-2544</a
+              class="text-gray-900 hover:text-red-600 font-bold transition-colors whitespace-nowrap"
+              >Call 814-315-2544</a
             >
           </nav>
-          <button
-            id="mobile-menu-button"
-            class="md:hidden text-gray-900 focus:outline-none"
-            aria-label="Toggle menu"
-          >
-            <svg
-              class="w-8 h-8"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </button>
-        </div>
-        <div
-          id="mobile-menu"
-          class="md:hidden hidden mt-4 flex flex-col space-y-2"
-          role="menu"
-          aria-label="Mobile navigation"
-        >
-          <a
-            href="#services"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >Services</a
-          >
-          <a
-            href="#about"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >About</a
-          >
-          <a
-            href="#contact"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >Contact</a
-          >
           <a
             href="tel:+18143152544"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >814-315-2544</a
+            class="md:hidden text-gray-900 hover:text-red-600 font-bold text-lg"
+            >Call 814-315-2544</a
           >
         </div>
       </div>
@@ -830,15 +787,6 @@
           }
         });
       });
-
-      // Mobile menu toggle
-      const menuButton = document.getElementById("mobile-menu-button");
-      const mobileMenu = document.getElementById("mobile-menu");
-      if (menuButton && mobileMenu) {
-        menuButton.addEventListener("click", () => {
-          mobileMenu.classList.toggle("hidden");
-        });
-      }
 
       // Add scroll effect to sticky CTA
       window.addEventListener("scroll", function () {

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -62,57 +62,14 @@
             >
             <a
               href="tel:+18143152544"
-              class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-              >814-315-2544</a
+              class="text-gray-900 hover:text-red-600 font-bold transition-colors whitespace-nowrap"
+              >Call 814-315-2544</a
             >
           </nav>
-          <button
-            id="mobile-menu-button"
-            class="md:hidden text-gray-900 focus:outline-none"
-            aria-label="Toggle menu"
-          >
-            <svg
-              class="w-8 h-8"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </button>
-        </div>
-        <div
-          id="mobile-menu"
-          class="md:hidden hidden mt-4 flex flex-col space-y-2"
-          role="menu"
-          aria-label="Mobile navigation"
-        >
-          <a
-            href="index.html#services"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >Services</a
-          >
-          <a
-            href="index.html#about"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >About</a
-          >
-          <a
-            href="index.html#contact"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >Contact</a
-          >
           <a
             href="tel:+18143152544"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >814-315-2544</a
+            class="md:hidden text-gray-900 hover:text-red-600 font-bold text-lg"
+            >Call 814-315-2544</a
           >
         </div>
       </div>
@@ -301,14 +258,6 @@
       </div>
     </footer>
 
-    <script>
-      const menuButton = document.getElementById("mobile-menu-button");
-      const mobileMenu = document.getElementById("mobile-menu");
-      if (menuButton && mobileMenu) {
-        menuButton.addEventListener("click", () => {
-          mobileMenu.classList.toggle("hidden");
-        });
-      }
-    </script>
+    
   </body>
 </html>

--- a/thank-you.html
+++ b/thank-you.html
@@ -62,57 +62,14 @@
             >
             <a
               href="tel:+18143152544"
-              class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-              >814-315-2544</a
+              class="text-gray-900 hover:text-red-600 font-bold transition-colors whitespace-nowrap"
+              >Call 814-315-2544</a
             >
           </nav>
-          <button
-            id="mobile-menu-button"
-            class="md:hidden text-gray-900 focus:outline-none"
-            aria-label="Toggle menu"
-          >
-            <svg
-              class="w-8 h-8"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </button>
-        </div>
-        <div
-          id="mobile-menu"
-          class="md:hidden hidden mt-4 flex flex-col space-y-2"
-          role="menu"
-          aria-label="Mobile navigation"
-        >
-          <a
-            href="index.html#services"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >Services</a
-          >
-          <a
-            href="index.html#about"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >About</a
-          >
-          <a
-            href="index.html#contact"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >Contact</a
-          >
           <a
             href="tel:+18143152544"
-            class="text-gray-900 hover:text-red-600 font-bold transition-colors"
-            >814-315-2544</a
+            class="md:hidden text-gray-900 hover:text-red-600 font-bold text-lg"
+            >Call 814-315-2544</a
           >
         </div>
       </div>
@@ -238,14 +195,6 @@
       </div>
     </footer>
 
-    <script>
-      const menuButton = document.getElementById("mobile-menu-button");
-      const mobileMenu = document.getElementById("mobile-menu");
-      if (menuButton && mobileMenu) {
-        menuButton.addEventListener("click", () => {
-          mobileMenu.classList.toggle("hidden");
-        });
-      }
-    </script>
+    
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace hamburger menu with persistent clickable phone number across pages
- style phone link responsively for mobile visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad47b54654833183dfeb10c948b84e