### PR TITLE
Use US flag emoji instead of red flag icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,14 +95,7 @@
                 Wiley Trucking Fleet
               </h1>
               <div class="flex items-center space-x-2">
-                <svg
-                  class="w-4 h-4 text-red-600"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <use href="icons.svg#icon-flag" />
-                </svg>
+                <span class="text-base" role="img" aria-label="United States flag">🇺🇸</span>
                 <span class="text-sm text-gray-900 font-bold">Erie, PA</span>
               </div>
             </div>
@@ -692,14 +685,7 @@
             </p>
             <div class="flex space-x-4">
               <div class="bg-red-600 p-2 rounded-full">
-                <svg
-                  class="w-5 h-5 text-white"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <use href="icons.svg#icon-flag" />
-                </svg>
+                <span class="block w-5 h-5" role="img" aria-label="United States flag">🇺🇸</span>
               </div>
               <span class="text-gray-300 text-sm font-bold"
                 >Proudly American Owned & Operated</span

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -32,14 +32,7 @@
                 Wiley Trucking Fleet
               </h1>
               <div class="flex items-center space-x-2">
-                <svg
-                  class="w-4 h-4 text-red-600"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <use href="icons.svg#icon-flag" />
-                </svg>
+                <span class="text-base" role="img" aria-label="United States flag">🇺🇸</span>
                 <span class="text-sm text-gray-900 font-bold">Erie, PA</span>
               </div>
             </div>
@@ -180,14 +173,7 @@
             </p>
             <div class="flex space-x-4">
               <div class="bg-red-600 p-2 rounded-full">
-                <svg
-                  class="w-5 h-5 text-white"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <use href="icons.svg#icon-flag" />
-                </svg>
+                <span class="block w-5 h-5" role="img" aria-label="United States flag">🇺🇸</span>
               </div>
               <span class="text-gray-300 text-sm font-bold"
                 >Proudly American Owned & Operated</span

--- a/thank-you.html
+++ b/thank-you.html
@@ -32,14 +32,7 @@
                 Wiley Trucking Fleet
               </h1>
               <div class="flex items-center space-x-2">
-                <svg
-                  class="w-4 h-4 text-red-600"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <use href="icons.svg#icon-flag" />
-                </svg>
+                <span class="text-base" role="img" aria-label="United States flag">🇺🇸</span>
                 <span class="text-sm text-gray-900 font-bold">Erie, PA</span>
               </div>
             </div>
@@ -117,14 +110,7 @@
             </p>
             <div class="flex space-x-4">
               <div class="bg-red-600 p-2 rounded-full">
-                <svg
-                  class="w-5 h-5 text-white"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <use href="icons.svg#icon-flag" />
-                </svg>
+                <span class="block w-5 h-5" role="img" aria-label="United States flag">🇺🇸</span>
               </div>
               <span class="text-gray-300 text-sm font-bold"
                 >Proudly American Owned & Operated</span


### PR DESCRIPTION
## Summary
- replace red flag SVG icon with 🇺🇸 emoji beside "Erie, PA" in header
- display 🇺🇸 emoji in footer badge highlighting American ownership

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4a0dd8f48331b32bdf38390e9b3a