### PR TITLE
Remove hazmat/TWIC references from marketing copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     </title>
     <meta
       name="description"
-      content="Wiley Trucking Fleet provides dependable, safety-first freight solutions across the U.S. with TWIC-certified drivers and real-time tracking."
+      content="Wiley Trucking Fleet provides dependable, safety-first freight solutions across the U.S. with experienced drivers and real-time tracking."
     />
     <meta
       name="keywords"
@@ -34,7 +34,7 @@
     />
     <meta
       property="og:description"
-      content="Wiley Trucking Fleet provides dependable, safety-first freight solutions across the U.S. with TWIC-certified drivers and real-time tracking."
+      content="Wiley Trucking Fleet provides dependable, safety-first freight solutions across the U.S. with experienced drivers and real-time tracking."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.wileytrucking.com/" />
@@ -50,7 +50,7 @@
     />
     <meta
       name="twitter:description"
-      content="Wiley Trucking Fleet provides dependable, safety-first freight solutions across the U.S. with TWIC-certified drivers and real-time tracking."
+      content="Wiley Trucking Fleet provides dependable, safety-first freight solutions across the U.S. with experienced drivers and real-time tracking."
     />
     <meta
       name="twitter:image"
@@ -319,13 +319,13 @@
               Tanker & Doubles/Triples
             </h3>
             <p class="text-base font-bold text-gray-900">
-              HazMat/TWIC as needed
+              Non-hazardous freight only
             </p>
           </a>
 
           <a
             href="#contact"
-            aria-label="Learn about TWIC-Certified Drivers"
+            aria-label="Learn about Experienced Drivers"
             class="service-card block bg-white p-6 rounded-2xl text-center transition-all duration-300"
           >
             <div
@@ -347,10 +347,10 @@
             <h3
               class="font-montserrat font-bold text-[22px] text-gray-900 tracking-tight mb-2"
             >
-              TWIC-Certified Drivers
+              Experienced Drivers
             </h3>
             <p class="text-base font-bold text-gray-900">
-              Access to secure sites
+              Reliable professional service
             </p>
           </a>
 
@@ -744,7 +744,7 @@
         >
           <p>
             &copy; 2024 Wiley Trucking Fleet. All rights reserved. | DOT
-            Compliant | TWIC Certified
+            Compliant | General Freight Specialists
           </p>
         </div>
       </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -238,7 +238,7 @@
         >
           <p>
             &copy; 2024 Wiley Trucking Fleet. All rights reserved. | DOT
-            Compliant | TWIC Certified
+            Compliant | General Freight Specialists
           </p>
         </div>
       </div>

--- a/thank-you.html
+++ b/thank-you.html
@@ -175,7 +175,7 @@
         >
           <p>
             &copy; 2024 Wiley Trucking Fleet. All rights reserved. | DOT
-            Compliant | TWIC Certified
+            Compliant | General Freight Specialists
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Update marketing copy to remove HazMat and TWIC references in meta descriptions and service cards, emphasizing experienced drivers and non-hazardous freight.
- Adjust footer text across pages to promote DOT-compliant general freight services.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f4509a68833195bbc5c707581a9e