### PR TITLE
Make logo link back to home

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
     <header class="bg-white shadow-sm">
       <div class="container mx-auto px-4 py-4">
         <div class="flex items-center justify-between">
-          <div class="flex items-center space-x-3">
+          <a href="index.html" class="flex items-center space-x-3">
             <img
               src="WTF.ico"
               alt="Wiley Trucking Fleet logo"
@@ -100,7 +100,7 @@
                 <span class="text-sm text-gray-900 font-bold">Erie, PA</span>
               </div>
             </div>
-          </div>
+          </a>
           <nav class="hidden md:flex space-x-8" aria-label="Primary navigation">
             <a
               href="#services"

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -22,7 +22,7 @@
     <header class="bg-white shadow-sm">
       <div class="container mx-auto px-4 py-4">
         <div class="flex items-center justify-between">
-          <div class="flex items-center space-x-3">
+          <a href="index.html" class="flex items-center space-x-3">
             <img
               src="WTF.ico"
               alt="Wiley Trucking Fleet logo"
@@ -37,7 +37,7 @@
                 <span class="text-sm text-gray-900 font-bold">Erie, PA</span>
               </div>
             </div>
-          </div>
+          </a>
           <nav class="hidden md:flex space-x-8" aria-label="Primary navigation">
             <a
               href="index.html#services"

--- a/thank-you.html
+++ b/thank-you.html
@@ -22,7 +22,7 @@
     <header class="bg-white shadow-sm">
       <div class="container mx-auto px-4 py-4">
         <div class="flex items-center justify-between">
-          <div class="flex items-center space-x-3">
+          <a href="index.html" class="flex items-center space-x-3">
             <img
               src="WTF.ico"
               alt="Wiley Trucking Fleet logo"
@@ -37,7 +37,7 @@
                 <span class="text-sm text-gray-900 font-bold">Erie, PA</span>
               </div>
             </div>
-          </div>
+          </a>
           <nav class="hidden md:flex space-x-8" aria-label="Primary navigation">
             <a
               href="index.html#services"


### PR DESCRIPTION
## Summary
- Make the site logo clickable and link it to the home page across all pages.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72477380483318b79409961699a51